### PR TITLE
ダミー投票の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.where.not(user_id: 999)
     @pickup_items = []
     User.order_voted.each do |user|
       next if user.items.on_sale.empty?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where.not(id: 1)
+    @users = User.where.not(id: 1).where.not(id: 999)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,5 +64,14 @@ n = 0
   end
 end
 
+# create dummy vote
+dummy_user = create_user(name: 'dummy')
+dummy_user.update!(id: 999)
+2.upto(13) do |i|
+  item = Item.create!(title: 'dummy', user: dummy_user, price: 1, txid: 'dummy', purchased_at: Time.current)
+  vote_token = VoteToken.create!(user: dummy_user, item:, token_id: 'dummy', amount: 1)
+  Vote.create!(votee: User.find(i), voter: dummy_user, vote_token:, amount: rand(50..300), txid: 'dummy')
+end
+
 # start block syncer
 `rails glueby:block_syncer:start`

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,23 +1,23 @@
 Faker::Config.locale = :ja
 
-n = 0
-titles = ['ドロップイヤリング ブラウン',
-          '目玉焼きのピンブローチ',
-          'KYUSU (kuro) / 急須 (黒)',
-          '本革 ネームタグ オイルレザー',
-          'ハーブ石鹸',
-          '手編みベビーシューズ',
-          'クリスマスオーナメント',
-          'アウターポンチョ ニット',
-          'キャンバストートバッグ',
-          '手編みニット帽子',
-          'ラウンドプレート レッド',
-          'ストライプ ガラスコップ',
-          '金木犀のアロマキャンドル',
-          '木のヨーグルトスプーン',
-          '木製 花瓶',
-          'ハーブ×フルーツジャム'
-        ]
+titles = [
+  'ドロップイヤリング ブラウン',
+  '目玉焼きのピンブローチ',
+  'KYUSU (kuro) / 急須 (黒)',
+  '本革 ネームタグ オイルレザー',
+  'ハーブ石鹸',
+  '手編みベビーシューズ',
+  'クリスマスオーナメント',
+  'アウターポンチョ ニット',
+  'キャンバストートバッグ',
+  '手編みニット帽子',
+  'ラウンドプレート レッド',
+  'ストライプ ガラスコップ',
+  '金木犀のアロマキャンドル',
+  '木のヨーグルトスプーン',
+  '木製 花瓶',
+  'ハーブ×フルーツジャム'
+]
 
 descriptions = [
   'ガーネット色とゴールド色組合わせがゴージャスなイヤリングです。華やかなデザインが装いのワンポイントにお勧めです',
@@ -38,30 +38,31 @@ descriptions = [
   '【手作り ハーブ×フルーツジャム】トーストやヨーグルトはもちろん、アイスクリームのトッピングにも最適です！'
 ]
 
-g_wallet = Glueby::Wallet.create
-wallet = Wallet.create! { |u| u.id = g_wallet.id }
-name = '秋本 隼勢'
-user = User.create!(name:, wallet_id: wallet.id)
-Glueby::Internal::RPC.client.generatetoaddress(1, g_wallet.internal_wallet.receive_address, ENV['AUTHORITY_KEY'])
-
-12.times do |i|
+def create_user(name: nil)
   g_wallet = Glueby::Wallet.create
   wallet = Wallet.create! { |u| u.id = g_wallet.id }
-  name = Faker::Name.name
-  user = User.create!(name:, wallet_id: wallet.id)
   Glueby::Internal::RPC.client.generatetoaddress(1, g_wallet.internal_wallet.receive_address, ENV['AUTHORITY_KEY'])
-  if i < 8
-    2.times do
-      title = titles[n]
-      description = descriptions[n]
-      price = rand(5..300) * 100
-      Item.create!(user_id: user.id,
-                  title:,
-                  description:,
-                  price:)
-      n+=1
-    end
+  User.create!(name: name || Faker::Name.name, wallet_id: wallet.id)
+end
+
+# create default user
+create_user(name: '秋本 隼勢')
+
+# create users
+n = 0
+12.times do |i|
+  user = create_user
+  next if i >= 8
+
+  # create items
+  2.times do
+    Item.create!(user_id: user.id,
+                 title: titles[n],
+                 description: descriptions[n],
+                 price: rand(5..300) * 100)
+    n += 1
   end
 end
 
+# start block syncer
 `rails glueby:block_syncer:start`

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,7 +70,7 @@ dummy_user.update!(id: 999)
 2.upto(13) do |i|
   item = Item.create!(title: 'dummy', user: dummy_user, price: 1, txid: 'dummy', purchased_at: Time.current)
   vote_token = VoteToken.create!(user: dummy_user, item:, token_id: 'dummy', amount: 1)
-  Vote.create!(votee: User.find(i), voter: dummy_user, vote_token:, amount: rand(50..300), txid: 'dummy')
+  Vote.create!(votee: User.find(i), voter: dummy_user, vote_token:, amount: rand(1..30) * 10, txid: 'dummy')
 end
 
 # start block syncer


### PR DESCRIPTION
## 概要
- Closes: #40 
- Ref. #8 

## 対応内容
- db/seeds.rb でダミー投票を作成するように変更
  - ダミーユーザーでダミー商品とダミーVoteTokenを作ってダミー投票を作成
- ユーザー一覧・商品一覧にダミーユーザーとその商品が表示されないように変更
- 初期時点で（自分以外のユーザーが投票した）ランダム数の得票がある状態に
  <img width="1321" alt="スクリーンショット 2022-11-06 午後9 30 04" src="https://user-images.githubusercontent.com/46078198/200170854-7a14054c-a829-4df0-9400-6528968a8c0e.png">

## 備考

