### PR TITLE
プロフィール画面の追加・クリエイター総選挙画面の更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby '3.1.2'
 gem 'rails', '~> 7.0.4'
 
 gem 'bootsnap', require: false
+gem "chartkick"
+gem 'chartable'
 gem 'cssbundling-rails'
 gem 'dotenv-rails'
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartable (0.0.0.3)
+      activesupport (>= 3.0.0)
+      chronic (~> 0.10)
+    chartkick (4.2.1)
     childprocess (4.1.0)
     choice (0.2.0)
+    chronic (0.10.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     cssbundling-rails (1.1.1)
@@ -305,6 +310,8 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  chartable
+  chartkick
   cssbundling-rails
   debug
   dotenv-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link chartkick.js

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where.not(id: 1).where.not(id: 999)
+    @users = User.where.not(id: 1).where.not(id: 999).order_voted
+  end
 
   def show
     @user = User.find(params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,10 @@
 class UsersController < ApplicationController
   def index
     @users = User.where.not(id: 1).where.not(id: 999)
+
+  def show
+    @user = User.find(params[:id])
+    @voteds_hash = @user.voteds.to_h { |voted| [voted.voter.name, voted.amount] }.sort_by { |_, v| -v }.to_h
+    @items = @user.items
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,7 @@ html
     = csp_meta_tag
     = stylesheet_link_tag "application", "data-turbo-track": "reload"
     = javascript_include_tag "application", "data-turbo-track": "reload", defer: true
+    = javascript_include_tag "//www.google.com/jsapi", "chartkick"
   body
     .container
       = render 'layouts/header'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,18 +1,25 @@
-h4 クリエイター総選挙
+h4.mb-3
+ | クリエイター総選挙
 
-- @users.each_slice(4) do |slice_users|
-  .row.my-4
-    - slice_users.each do |user|
-      .col-md-3
-        .card
-          .card-body
-            h5.card-title
+.row
+  .col-md-8
+    ol.list-group.list-group-numbered.list-group-flush
+      - @users.each do |user|
+        = link_to user, class: 'list-group-item d-flex justify-content-between align-items-start'
+          .ms-2.me-auto
+            h4.fw-bold
               = user.name
-            p.card-text
-              = "得票数: #{user.number_of_voteds.to_fs(:delimited)}"
-            - if user.voteds.where(voter_id: User.find(1).id).pluck(:amount).sum.zero?
+            h5
+              = "#{user.number_of_voteds.to_fs(:delimited)}票"
+          - user.voteds.each do |voted|
+            span.badge.bg-success.rounded-pill.me-2
+              = voted.voter.name[0]
 
-            - else
-              p.card-text
-                = "#{user.voteds.where(voter_id: User.find(1).id).pluck(:amount).sum}票投票しました"
-            = link_to '投票', votes_progress_path(votee_id: user.id), class: 'btn btn-block btn-outline-primary btn-sm'
+  .col-md-4
+    .card.card-body
+      strong.card-title
+        | 投票の仕方
+      .card-text
+        | 1. 商品を購入します。購入額に応じた購入者トークンが付与されます。
+      .card-text
+        | 2. 購入者トークンで応援したいクリエイターに投票します。投票分のトークンはクリエイターに送付されます。

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,0 +1,42 @@
+.d-flex.justify-content-between.align-items-start
+  h4
+    = @user.name
+  = link_to '投票', votes_progress_path(votee_id: @user.id), class: 'btn btn-block btn-outline-primary btn-sm'
+
+.row
+  .col
+    h5.mt-3
+      | 得票状況
+    .card
+      .card-body
+        ul.list-group.list-group-flush
+          - @voteds_hash.each do |voted|
+            li.list-group-item.list-group-horizontal.d-flex.justify-content-between.align-items-start
+              p
+                = voted[0]
+              p
+                = "#{voted[1].to_fs(:delimited)}票"
+        = pie_chart @voteds_hash
+
+  .col
+    h5.mt-3
+      | 出品中のアイテム
+    - if @items.empty?
+      | なし
+    - @items.each do |item|
+      .card.mb-2
+        .row.g-0
+          .col-md-4
+            = image_tag "#{item.id}.jpg", height:200, width: 200, style: "object-fit: cover"
+          .col-md-8.
+            .card-body
+              p.card-title
+                = item.title
+              p.card-text
+                = item.description.truncate(35)
+              .card-text
+                = "RHA #{item.price.to_fs(:delimited)}"
+              - if item.purchased_at.nil?
+                = link_to '購入', orders_progress_path(item_id: item.id), class: 'btn btn-block btn-outline-primary btn-sm'
+              - else
+                .btn.btn-outline-secondary.btn-block.btn-sm.disabled 購入済み

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'items#index'
 
   resources :items, only: %i[index]
-  resources :users, only: %i[index]
+  resources :users, only: %i[index show]
   resources :vote_tokens, only: %i[index]
   resources :transactions, only: %i[show]
   resources :reset, only: %i[index create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,7 @@ def create_user(name: nil)
 end
 
 # create default user
-create_user(name: '秋本 隼勢')
+create_user(name: '嶋村 颯人')
 
 # create users
 n = 0
@@ -67,10 +67,13 @@ end
 # create dummy vote
 dummy_user = create_user(name: 'dummy')
 dummy_user.update!(id: 999)
-2.upto(13) do |i|
-  item = Item.create!(title: 'dummy', user: dummy_user, price: 1, txid: 'dummy', purchased_at: Time.current)
-  vote_token = VoteToken.create!(user: dummy_user, item:, token_id: 'dummy', amount: 1)
-  Vote.create!(votee: User.find(i), voter: dummy_user, vote_token:, amount: rand(1..30), txid: 'dummy')
+users = User.where.not(id: 1).where.not(id: 999)
+3.times do
+  users.each do |user|
+    item = Item.create!(title: 'dummy', user: dummy_user, price: 1, txid: 'dummy', purchased_at: Time.current)
+    vote_token = VoteToken.create!(user: user, item:, token_id: 'dummy', amount: 1)
+    Vote.create!(votee: users.where.not(id: user.id).order("RANDOM()").first, voter: user, vote_token:, amount: rand(1..30), txid: 'dummy')
+  end
 end
 
 # start block syncer

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.1",
     "bootstrap-icons": "^1.9.1",
+    "chart.js": "^4.0.1",
+    "chartkick": "^4.2.0",
     "esbuild": "^0.15.7",
     "sass": "^1.54.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,25 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+chart.js@>=3.0.2, chart.js@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.0.1.tgz#93d5d50ac222a5b3b6ac7488e82e1553ac031592"
+  integrity sha512-5/8/9eBivwBZK81mKvmIwTb2Pmw4D/5h1RK9fBWZLLZ8mCJ+kfYNmV9rMrGoa5Hgy2/wVDBMLSUDudul2/9ihA==
+
+chartjs-adapter-date-fns@>=2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-2.0.1.tgz#3d007d4985391362fb15c96310fff8376a434bae"
+  integrity sha512-v3WV9rdnQ05ce3A0ZCjzUekJCAbfm6+3HqSoeY2BIkdMYZoYr/4T+ril1tZyDl869lz6xdNVMXejUFT9YKpw4A==
+
+chartkick@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-4.2.0.tgz#106fc5ff7eef5343a9e6977f259a8a8a1ea57bf9"
+  integrity sha512-7yYZyxeFhOh/LA7gc1VwDFgc6t4ZM9RrbBjgb4dJoFukk2+94QkK0yulYI2OUH1cjcfrf1qmj04FkjZx7kZDeg==
+  optionalDependencies:
+    chart.js ">=3.0.2"
+    chartjs-adapter-date-fns ">=2.0.0"
+    date-fns ">=2.0.0"
+
 "chokidar@>=3.0.0 <4.0.0":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -79,6 +98,11 @@ braces@~3.0.2:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+date-fns@>=2.0.0:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 esbuild-android-64@0.15.7:
   version "0.15.7"


### PR DESCRIPTION
## 概要
- ゼミで言われた内容

## 対応内容
- user#show を追加
  ![Screenshot 2022-12-03 at 17 12 04](https://user-images.githubusercontent.com/46078198/205473145-fe0e79ac-912d-4850-a44a-7c9458fdca78.png)
- chartkick を導入、円グラフを表示
- クリエイター総選挙画面を得票数順にソート、投票者アイコンを表示
  - アイコンはユーザー名頭文字を取ったバッチで実装
  ![Screenshot 2022-12-03 at 17 11 54](https://user-images.githubusercontent.com/46078198/205473143-0e97dcee-5103-48c9-8792-0c75029843cf.png)
- db/seeds.rb を更新
  - 各ユーザーが3回ランダムなユーザーに対し投票するように変更 

## 備考
<!-- その他通達事項 -->
